### PR TITLE
chore: use shared renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,40 +1,11 @@
 {
-  "extends": ["config:base"],
-  "reviewers": ["co-sic", "dimitriSaplatkin"],
-  "reviewersSampleSize": 1,
-  "dependencyDashboard": true,
-  "labels": ["dependencies"],
-  "packageRules": [
-    {
-      "groupName": "dependencies (non-major)",
-      "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true,
-      "schedule": ["before 8am on Monday"]
-    },
-    {
-      "groupName": "devDependencies",
-      "addLabels": ["devDependencies"],
-      "matchDepTypes": ["devDependencies"],
-      "automerge": true,
-      "schedule": ["before 8am on Monday"]
-    },
-    {
-      "groupName": "devDependencies (main-workflow)",
-      "addLabels": ["devDependencies"],
-      "matchFiles": ["main.yml"],
-      "matchUpdateTypes": ["major"],
-      "automerge": false,
-      "schedule": ["before 8am on Monday"]
-    },
-    {
-      "groupName": "semantic-release",
-      "addLabels": ["devDependencies", "semantic-release"],
-      "matchPackagePatterns": "semantic-release",
-      "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": ["major"],
-      "automerge": false,
-      "schedule": ["before 8am on Monday"]
-    }
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>gastromatic/renovate-config"
   ],
-  "schedule": ["before 8am"]
+  "reviewers": [
+    "co-sic",
+    "dimitriSaplatkin"
+  ],
+  "reviewersSampleSize": 1
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,11 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>gastromatic/renovate-config"
-  ],
-  "reviewers": [
-    "co-sic",
-    "dimitriSaplatkin"
-  ],
+  "extends": ["github>gastromatic/renovate-config"],
+  "reviewers": ["co-sic", "dimitriSaplatkin"],
   "reviewersSampleSize": 1
 }


### PR DESCRIPTION
### WHAT

Replaces this repo's hand-maintained Renovate config with `github>gastromatic/renovate-config`, keeping only what is genuinely repo-specific.

```json
{
  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
  "extends": [
    "github>gastromatic/renovate-config"
  ],
  "reviewers": [
    "co-sic",
    "dimitriSaplatkin"
  ],
  "reviewersSampleSize": 1
}
```

### Removed, because the shared config already provides it

- `extends: config:base` — the shared config extends `config:recommended` (`config:base` is a deprecated alias Renovate migrates to it anyway)
- `dependencyDashboard: true` — comes from `:dependencyDashboard` in `config:recommended`
- `labels: ["dependencies"]` — set by the shared config
- `schedule` — the shared config runs Sunday 20:00–23:59 Europe/Berlin
- the `devDependencies` / `devDependencies (non-major)` groups — the shared config groups non-major devDependencies into one automerged PR and lets Renovate's built-in monorepo groups handle the majors
- the `semantic-release` group — present in the shared config
- `devDependencies (main-workflow)` — the shared config has a broader `devDependencies (workflow)` rule for `**/*.yml`; the rule also used `matchFiles`, which Renovate has since removed in favour of `matchFileNames`

### Worth knowing

- Two automerge behaviours are dropped: runtime `dependencies` minor/patch were automerged here, and so were devDependency majors. The shared config automerges non-major devDependencies only.
- The shared config also brings `minimumReleaseAge: 3 days`, `prConcurrentLimit: 15` and `rebaseWhen: conflicted`.
- Reviewers and `reviewersSampleSize` are unchanged.

Part of aligning the repos that still carry a copy-pasted config — see gastromatic/renovate-config#7 for the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)